### PR TITLE
サンプルコードのリンク先の変更

### DIFF
--- a/1/1.md
+++ b/1/1.md
@@ -10,7 +10,7 @@ HTMLでWebサイトを記述し、CSSで装飾、JavaScriptをつかってWebサ
 JavaScriptについてはSTEP1-3、HTMLとCSSについてはSTEP1-4で後ほど詳しく説明します。
 
 ### サンプルコードを動かす
-サンプルコードは[step1sample](https://github.com/farundorL/step1sample)にアクセスして、右下にあるDownloadZIPをクリックしてダウンロードしてください。
+サンプルコードは[step1sample](https://github.com/team-lab/step1sample)にアクセスして、右下にあるDownloadZIPをクリックしてダウンロードしてください。
 ![](../images/1_1_zip.png)
 保存したファイルを解凍すると、中には4つのファイルがあるはずです。
 <table>


### PR DESCRIPTION
* 文字コード設定の無いHTMLをデフォルト設定のChromeで閲覧すると、強制的にshift_jisとして解釈される
* サンプルページがUTF-8で書かれており、文字コードの設定が無い

上記の理由により、Chromeで閲覧したとき、サンプルページが文字化けしてしまっていました。
Forkして文字コード設定を直したので、リポジトリのリンク先を変更しました。